### PR TITLE
Use light status and navigation bars with light primary colors when possible

### DIFF
--- a/library/src/main/java/com/jaredrummler/cyanea/Cyanea.kt
+++ b/library/src/main/java/com/jaredrummler/cyanea/Cyanea.kt
@@ -27,6 +27,7 @@ import android.content.res.ColorStateList
 import android.content.res.Resources
 import android.graphics.Color
 import android.graphics.drawable.Drawable
+import android.os.Build
 import android.os.Handler
 import android.util.Log
 import android.util.TypedValue
@@ -475,7 +476,7 @@ class Cyanea private constructor(private val prefs: SharedPreferences) {
       primaryDark(ColorUtils.darker(color, DEFAULT_DARKER_FACTOR))
       primaryLight(ColorUtils.lighter(color, DEFAULT_LIGHTER_FACTOR))
       menuIconColor(res.getColor(menuIconColorRes))
-      navigationBar(if (isDarkColor) color else Color.BLACK)
+      navigationBar(if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O || isDarkColor) color else Color.BLACK)
       return this
     }
 

--- a/library/src/main/java/com/jaredrummler/cyanea/delegate/CyaneaDelegate.kt
+++ b/library/src/main/java/com/jaredrummler/cyanea/delegate/CyaneaDelegate.kt
@@ -120,6 +120,7 @@ abstract class CyaneaDelegate {
     @JvmStatic
     fun create(activity: Activity, cyanea: Cyanea, @StyleRes themeResId: Int): CyaneaDelegate {
       return when {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O -> CyaneaDelegateImplV26(activity, cyanea, themeResId)
         Build.VERSION.SDK_INT >= Build.VERSION_CODES.N -> CyaneaDelegateImplV24(activity, cyanea, themeResId)
         Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> CyaneaDelegateImplV23(activity, cyanea, themeResId)
         Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP -> CyaneaDelegateImplV21(activity, cyanea, themeResId)

--- a/library/src/main/java/com/jaredrummler/cyanea/delegate/CyaneaDelegateImplBase.kt
+++ b/library/src/main/java/com/jaredrummler/cyanea/delegate/CyaneaDelegateImplBase.kt
@@ -150,21 +150,25 @@ internal open class CyaneaDelegateImplBase(
     SystemBarTint(activity).run {
       setActionBarColor(cyanea.primary)
       if (cyanea.shouldTintStatusBar) {
-        tintStatusBar(this, cyanea.primaryDark)
+        tintStatusBar(cyanea.primaryDark, this)
       }
       if (cyanea.shouldTintNavBar) {
-        tintNavigationBar(this, cyanea.navigationBar)
+        tintNavigationBar(cyanea.navigationBar, this)
       }
     }
   }
 
-  protected open fun tintStatusBar() = tintStatusBar(SystemBarTint(activity), cyanea.primaryDark)
-
-  protected open fun tintStatusBar(tinter: SystemBarTint, color: Int) {
+  protected open fun tintStatusBar(
+    color: Int = cyanea.primaryDark,
+    tinter: SystemBarTint = SystemBarTint(activity)
+  ) {
     tinter.setStatusBarColor(color)
   }
 
-  protected open fun tintNavigationBar(tinter: SystemBarTint, color: Int) {
+  protected open fun tintNavigationBar(
+    color: Int = cyanea.navigationBar,
+    tinter: SystemBarTint = SystemBarTint(activity)
+  ) {
     tinter.setNavigationBarColor(color)
   }
 

--- a/library/src/main/java/com/jaredrummler/cyanea/delegate/CyaneaDelegateImplBase.kt
+++ b/library/src/main/java/com/jaredrummler/cyanea/delegate/CyaneaDelegateImplBase.kt
@@ -150,15 +150,23 @@ internal open class CyaneaDelegateImplBase(
     SystemBarTint(activity).run {
       setActionBarColor(cyanea.primary)
       if (cyanea.shouldTintStatusBar) {
-        setStatusBarColor(cyanea.primaryDark)
+        tintStatusBar(this, cyanea.primaryDark)
       }
       if (cyanea.shouldTintNavBar) {
-        setNavigationBarColor(cyanea.navigationBar)
+        tintNavigationBar(this, cyanea.navigationBar)
       }
     }
   }
 
-  protected open fun tintStatusBar() = SystemBarTint(activity).setStatusBarColor(cyanea.primaryDark)
+  protected open fun tintStatusBar() = tintStatusBar(SystemBarTint(activity), cyanea.primaryDark)
+
+  protected open fun tintStatusBar(tinter: SystemBarTint, color: Int) {
+    tinter.setStatusBarColor(color)
+  }
+
+  protected open fun tintNavigationBar(tinter: SystemBarTint, color: Int) {
+    tinter.setNavigationBarColor(color)
+  }
 
   protected open fun getProcessorsForTheming(): List<CyaneaViewProcessor<out View>> {
     return arrayListOf(

--- a/library/src/main/java/com/jaredrummler/cyanea/delegate/CyaneaDelegateImplV23.kt
+++ b/library/src/main/java/com/jaredrummler/cyanea/delegate/CyaneaDelegateImplV23.kt
@@ -100,8 +100,8 @@ internal open class CyaneaDelegateImplV23(
     }
   }
 
-  override fun tintStatusBar(tinter: SystemBarTint, color: Int) {
-    super.tintStatusBar(tinter, color)
+  override fun tintStatusBar(color: Int, tinter: SystemBarTint) {
+    super.tintStatusBar(color, tinter)
     if (!ColorUtils.isDarkColor(color)) {
       activity.window.decorView.run {
         systemUiVisibility = systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR

--- a/library/src/main/java/com/jaredrummler/cyanea/delegate/CyaneaDelegateImplV23.kt
+++ b/library/src/main/java/com/jaredrummler/cyanea/delegate/CyaneaDelegateImplV23.kt
@@ -22,6 +22,7 @@ import android.app.Activity
 import android.content.res.ColorStateList
 import android.os.Build
 import android.os.Bundle
+import android.view.View
 import androidx.annotation.RequiresApi
 import com.jaredrummler.cyanea.Cyanea
 import com.jaredrummler.cyanea.R
@@ -39,6 +40,8 @@ import com.jaredrummler.cyanea.inflator.SwitchProcessor
 import com.jaredrummler.cyanea.inflator.TextViewProcessor
 import com.jaredrummler.cyanea.inflator.TimePickerProcessor
 import com.jaredrummler.cyanea.inflator.ViewGroupProcessor
+import com.jaredrummler.cyanea.tinting.SystemBarTint
+import com.jaredrummler.cyanea.utils.ColorUtils
 import com.jaredrummler.cyanea.utils.Reflection
 
 @RequiresApi(Build.VERSION_CODES.M)
@@ -94,6 +97,15 @@ internal open class CyaneaDelegateImplV23(
     PRELOADED_DRAWABLES.forEach {
       // Update the drawable's ConstantState before views are inflated.
       activity.resources.getDrawable(it, activity.theme)
+    }
+  }
+
+  override fun tintStatusBar(tinter: SystemBarTint, color: Int) {
+    super.tintStatusBar(tinter, color)
+    if (!ColorUtils.isDarkColor(color)) {
+      activity.window.decorView.run {
+        systemUiVisibility = systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+      }
     }
   }
 

--- a/library/src/main/java/com/jaredrummler/cyanea/delegate/CyaneaDelegateImplV26.kt
+++ b/library/src/main/java/com/jaredrummler/cyanea/delegate/CyaneaDelegateImplV26.kt
@@ -1,0 +1,33 @@
+package com.jaredrummler.cyanea.delegate
+
+import android.annotation.TargetApi
+import android.app.Activity
+import android.os.Build
+import android.view.View
+import androidx.annotation.RequiresApi
+import com.jaredrummler.cyanea.Cyanea
+import com.jaredrummler.cyanea.tinting.SystemBarTint
+import com.jaredrummler.cyanea.utils.ColorUtils
+
+@RequiresApi(Build.VERSION_CODES.O)
+@TargetApi(Build.VERSION_CODES.O)
+internal open class CyaneaDelegateImplV26(
+  private val activity: Activity,
+  cyanea: Cyanea,
+  themeResId: Int
+) : CyaneaDelegateImplV24(activity, cyanea, themeResId) {
+
+  override fun tintNavigationBar(tinter: SystemBarTint, color: Int) {
+    super.tintNavigationBar(tinter, color)
+    if (!ColorUtils.isDarkColor(color)) {
+      activity.window.decorView.run {
+        systemUiVisibility = systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+      }
+    }
+  }
+
+  companion object {
+    private const val TAG = "CyaneaDelegateImplV26"
+  }
+
+}

--- a/library/src/main/java/com/jaredrummler/cyanea/delegate/CyaneaDelegateImplV26.kt
+++ b/library/src/main/java/com/jaredrummler/cyanea/delegate/CyaneaDelegateImplV26.kt
@@ -17,8 +17,8 @@ internal open class CyaneaDelegateImplV26(
   themeResId: Int
 ) : CyaneaDelegateImplV24(activity, cyanea, themeResId) {
 
-  override fun tintNavigationBar(tinter: SystemBarTint, color: Int) {
-    super.tintNavigationBar(tinter, color)
+  override fun tintNavigationBar(color: Int, tinter: SystemBarTint) {
+    super.tintNavigationBar(color, tinter)
     if (!ColorUtils.isDarkColor(color)) {
       activity.window.decorView.run {
         systemUiVisibility = systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR

--- a/library/src/main/java/com/jaredrummler/cyanea/prefs/CyaneaSettingsFragment.kt
+++ b/library/src/main/java/com/jaredrummler/cyanea/prefs/CyaneaSettingsFragment.kt
@@ -168,7 +168,7 @@ open class CyaneaSettingsFragment : PreferenceFragmentCompat(), OnPreferenceChan
 
   private fun setupNavBarPref() {
     ColorUtils.isDarkColor(cyanea.primary, 0.75).let { isDarkEnough ->
-      prefColorNavBar.isEnabled = isDarkEnough
+      prefColorNavBar.isEnabled = isDarkEnough || VERSION.SDK_INT >= VERSION_CODES.O
     }
     val isColored = if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
       activity?.window?.navigationBarColor == cyanea.primary

--- a/library/src/main/java/com/jaredrummler/cyanea/prefs/CyaneaTheme.kt
+++ b/library/src/main/java/com/jaredrummler/cyanea/prefs/CyaneaTheme.kt
@@ -18,6 +18,7 @@ package com.jaredrummler.cyanea.prefs
 
 import android.content.res.AssetManager
 import android.graphics.Color
+import android.os.Build
 import androidx.annotation.ColorInt
 import com.jaredrummler.cyanea.Cyanea
 import com.jaredrummler.cyanea.Cyanea.BaseTheme
@@ -251,7 +252,11 @@ data class CyaneaTheme internal constructor(
       val navigationBarColor = if (json.has(NAVIGATION_BAR_COLOR)) {
         ColorUtils.parseColor(json.getString(NAVIGATION_BAR_COLOR))
       } else {
-        if (ColorUtils.isDarkColor(primary, 0.75)) primary else Color.BLACK
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O || ColorUtils.isDarkColor(primary, 0.75)) {
+          primary
+        } else {
+          Color.BLACK
+        }
       }
 
       // Get the tinting flags

--- a/library/src/main/java/com/jaredrummler/cyanea/tinting/SystemBarTint.kt
+++ b/library/src/main/java/com/jaredrummler/cyanea/tinting/SystemBarTint.kt
@@ -41,6 +41,7 @@ import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import com.jaredrummler.cyanea.Cyanea
 import com.jaredrummler.cyanea.delegate.BaseAppCompatDelegate
+import com.jaredrummler.cyanea.utils.ColorUtils
 import com.jaredrummler.cyanea.utils.Reflection
 import java.lang.ref.WeakReference
 
@@ -146,7 +147,8 @@ class SystemBarTint(activity: Activity) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       val activity = activityRef.get() ?: return
       activity.window.statusBarColor = color
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Cyanea.instance.isActionBarLight) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !ColorUtils.isDarkColor(
+          Cyanea.instance.primaryDark)) {
         activity.window.decorView.run {
           systemUiVisibility = systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
         }

--- a/library/src/main/java/com/jaredrummler/cyanea/tinting/SystemBarTint.kt
+++ b/library/src/main/java/com/jaredrummler/cyanea/tinting/SystemBarTint.kt
@@ -39,6 +39,7 @@ import android.widget.FrameLayout.LayoutParams
 import androidx.annotation.ColorInt
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
+import com.jaredrummler.cyanea.Cyanea
 import com.jaredrummler.cyanea.delegate.BaseAppCompatDelegate
 import com.jaredrummler.cyanea.utils.Reflection
 import java.lang.ref.WeakReference
@@ -145,6 +146,11 @@ class SystemBarTint(activity: Activity) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       val activity = activityRef.get() ?: return
       activity.window.statusBarColor = color
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Cyanea.instance.isActionBarLight) {
+        activity.window.decorView.run {
+          systemUiVisibility = systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+        }
+      }
       return
     }
     if (isStatusBarAvailable && statusBarTintView != null) {
@@ -164,6 +170,11 @@ class SystemBarTint(activity: Activity) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       val activity = activityRef.get() ?: return
       activity.window.navigationBarColor = color
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && Cyanea.instance.isActionBarLight) {
+        activity.window.decorView.run {
+          systemUiVisibility = systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+        }
+      }
       return
     }
     if (isNavBarAvailable && navBarTintView != null) {

--- a/library/src/main/java/com/jaredrummler/cyanea/tinting/SystemBarTint.kt
+++ b/library/src/main/java/com/jaredrummler/cyanea/tinting/SystemBarTint.kt
@@ -39,7 +39,6 @@ import android.widget.FrameLayout.LayoutParams
 import androidx.annotation.ColorInt
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
-import com.jaredrummler.cyanea.Cyanea
 import com.jaredrummler.cyanea.delegate.BaseAppCompatDelegate
 import com.jaredrummler.cyanea.utils.ColorUtils
 import com.jaredrummler.cyanea.utils.Reflection
@@ -147,8 +146,7 @@ class SystemBarTint(activity: Activity) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       val activity = activityRef.get() ?: return
       activity.window.statusBarColor = color
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !ColorUtils.isDarkColor(
-          Cyanea.instance.primaryDark)) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !ColorUtils.isDarkColor(color)) {
         activity.window.decorView.run {
           systemUiVisibility = systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
         }
@@ -172,7 +170,7 @@ class SystemBarTint(activity: Activity) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       val activity = activityRef.get() ?: return
       activity.window.navigationBarColor = color
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && Cyanea.instance.isActionBarLight) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !ColorUtils.isDarkColor(color)) {
         activity.window.decorView.run {
           systemUiVisibility = systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
         }

--- a/library/src/main/java/com/jaredrummler/cyanea/tinting/SystemBarTint.kt
+++ b/library/src/main/java/com/jaredrummler/cyanea/tinting/SystemBarTint.kt
@@ -40,7 +40,6 @@ import androidx.annotation.ColorInt
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import com.jaredrummler.cyanea.delegate.BaseAppCompatDelegate
-import com.jaredrummler.cyanea.utils.ColorUtils
 import com.jaredrummler.cyanea.utils.Reflection
 import java.lang.ref.WeakReference
 
@@ -146,11 +145,6 @@ class SystemBarTint(activity: Activity) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       val activity = activityRef.get() ?: return
       activity.window.statusBarColor = color
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !ColorUtils.isDarkColor(color)) {
-        activity.window.decorView.run {
-          systemUiVisibility = systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-        }
-      }
       return
     }
     if (isStatusBarAvailable && statusBarTintView != null) {
@@ -170,11 +164,6 @@ class SystemBarTint(activity: Activity) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       val activity = activityRef.get() ?: return
       activity.window.navigationBarColor = color
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !ColorUtils.isDarkColor(color)) {
-        activity.window.decorView.run {
-          systemUiVisibility = systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
-        }
-      }
       return
     }
     if (isNavBarAvailable && navBarTintView != null) {


### PR DESCRIPTION
Implements #43.

Edit: One thing I noticed is the built-in "SigFig" theme has a very dark `colorPrimaryDark` that makes the status bar unreadable. Maybe we should introduce a property `isStatusBarLight` instead of using `isActionBarLight`.

Edit2: I added a new commit calculating luminance from the primaryDark color. I've used the default factor of `0.5f` since it's the one that provides better results with all the built-in themes.